### PR TITLE
Specify minimum aiohttp version, accept newer ones

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,7 @@ name = "pypi"
 
 [packages]
 
-aiohttp = "~=3.0.5"
+aiohttp = ">=3.0.5"
 
 
 [dev-packages]


### PR DESCRIPTION
Hello,
I hope you don't mind me submitting this PR. We use slacker-asyncio with opsdroid and we rely on both slacker and aiohttp. Unfortunately, we have got some issues where we upgraded aiohttp to the latest version (3.3.2) but slacker requires the version 3.0.5.

With this PR I simply specified the minimum version of aiohttp to be 3.0.5 but accept newer versions as well.

I am not sure if this is something you would like, but please let me know your opinion on this.

Thank you